### PR TITLE
Review `AsymmetricCrypto` trait + use KEM/DEM in `Header`

### DIFF
--- a/src/asymmetric/mod.rs
+++ b/src/asymmetric/mod.rs
@@ -45,7 +45,11 @@ pub trait AsymmetricCrypto: Send + Sync + Default {
         parameters: Option<&Self::KeyPairGenerationParameters>,
     ) -> Result<Self::KeyPair, Error>;
 
-    /// Encrypt a message
+    /// Encrypt a message using the given public key.
+    ///
+    /// - `public_key`              : public key to use to encrypt
+    /// - `encryption_paramters`    : optional additional paramters
+    /// - `data`                    : message to encrypt
     fn encrypt(
         &self,
         public_key: &<Self::KeyPair as KeyPair>::PublicKey,
@@ -53,10 +57,13 @@ pub trait AsymmetricCrypto: Send + Sync + Default {
         data: &[u8],
     ) -> Result<Vec<u8>, Error>;
 
-    /// Decrypt a message
+    /// Decrypt a message using the given private key.
+    ///
+    /// - `private_key` : private key to use for decryption
+    /// - `ciphertext`  : ciphertext
     fn decrypt(
         &self,
         private_key: &<Self::KeyPair as KeyPair>::PrivateKey,
-        cipher_text: &[u8],
+        ciphertext: &[u8],
     ) -> Result<Vec<u8>, Error>;
 }

--- a/src/asymmetric/mod.rs
+++ b/src/asymmetric/mod.rs
@@ -1,4 +1,4 @@
-use crate::{symmetric_crypto::SymmetricCrypto, Error, KeyTrait};
+use crate::{Error, KeyTrait};
 use std::vec::Vec;
 
 pub mod ristretto;
@@ -40,39 +40,10 @@ pub trait AsymmetricCrypto: Send + Sync + Default {
     fn description(&self) -> String;
 
     /// Generate a key pair, private key and public key
-    fn generate_key_pair(
+    fn key_gen(
         &self,
         parameters: Option<&Self::KeyPairGenerationParameters>,
     ) -> Result<Self::KeyPair, Error>;
-
-    /// Generate a private key
-    fn generate_private_key(
-        &self,
-        parameters: Option<&Self::PrivateKeyGenerationParameters>,
-    ) -> Result<<Self::KeyPair as KeyPair>::PrivateKey, Error>;
-
-    /// Generate a symmetric key, and its encryption,to be used in an hybrid
-    /// encryption scheme
-    fn generate_symmetric_key<S: SymmetricCrypto>(
-        &self,
-        public_key: &<Self::KeyPair as KeyPair>::PublicKey,
-        encryption_parameters: Option<&Self::EncryptionParameters>,
-    ) -> Result<(S::Key, Vec<u8>), Error>;
-
-    /// Decrypt a symmetric key used in an hybrid encryption scheme
-    fn decrypt_symmetric_key<S: SymmetricCrypto>(
-        &self,
-        private_key: &<Self::KeyPair as KeyPair>::PrivateKey,
-        encrypted_symmetric_key: &[u8],
-    ) -> Result<S::Key, Error>;
-
-    /// A utility function to generate random bytes from an uniform distribution
-    /// using a cryptographically secure RNG
-    fn generate_random_bytes(&self, len: usize) -> Vec<u8>;
-
-    /// The encrypted message length - this may not be known in certain schemes
-    /// in which case zero is returned
-    fn encrypted_message_length(&self, clear_text_message_length: usize) -> usize;
 
     /// Encrypt a message
     fn encrypt(
@@ -81,10 +52,6 @@ pub trait AsymmetricCrypto: Send + Sync + Default {
         encryption_parameters: Option<&Self::EncryptionParameters>,
         data: &[u8],
     ) -> Result<Vec<u8>, Error>;
-
-    /// The decrypted message length - this may not be known in certain schemes
-    /// in which case zero is returned
-    fn clear_text_message_length(encrypted_message_length: usize) -> usize;
 
     /// Decrypt a message
     fn decrypt(

--- a/src/asymmetric/ristretto.rs
+++ b/src/asymmetric/ristretto.rs
@@ -354,17 +354,17 @@ impl AsymmetricCrypto for X25519Crypto {
     fn decrypt(
         &self,
         private_key: &<Self::KeyPair as KeyPair>::PrivateKey,
-        cipher_text: &[u8],
+        ciphertext: &[u8],
     ) -> Result<Vec<u8>, Error> {
-        if cipher_text.len() < X25519PublicKey::LENGTH * 2 {
+        if ciphertext.len() < X25519PublicKey::LENGTH * 2 {
             return Err(Error::SizeError {
-                given: cipher_text.len(),
+                given: ciphertext.len(),
                 expected: X25519PublicKey::LENGTH * 2,
             });
         }
         let c = (
-            X25519PublicKey::try_from(&cipher_text[..X25519PublicKey::LENGTH])?,
-            X25519PublicKey::try_from(&cipher_text[X25519PublicKey::LENGTH..])?,
+            X25519PublicKey::try_from(&ciphertext[..X25519PublicKey::LENGTH])?,
+            X25519PublicKey::try_from(&ciphertext[X25519PublicKey::LENGTH..])?,
         );
         let m = &c.0 - &(c.1 * private_key);
         Ok(m.to_bytes())

--- a/src/hybrid_crypto/dem.rs
+++ b/src/hybrid_crypto/dem.rs
@@ -39,6 +39,14 @@ impl Dem for Aes256GcmCrypto {
                 expected: Self::Key::LENGTH,
             });
         }
+
+        if E.len() < Self::Nonce::LENGTH {
+            return Err(Error::SizeError {
+                given: K.len(),
+                expected: Self::Nonce::LENGTH,
+            });
+        }
+
         // AES GCM includes an authentication method
         // there is no need for parsing a MAC key
         let key = Self::Key::try_from(&K[..Self::Key::LENGTH])?;

--- a/src/hybrid_crypto/kem.rs
+++ b/src/hybrid_crypto/kem.rs
@@ -27,7 +27,7 @@ impl Kem for X25519Crypto {
         rng: &mut R,
         pk: &<Self::KeyPair as KeyPair>::PublicKey,
     ) -> Result<(Vec<u8>, Vec<u8>), Error> {
-        let ephemeral_keypair = Self::key_gen(rng);
+        let ephemeral_keypair = <Self as Kem>::key_gen(rng);
 
         // encapsulation
         let E = ephemeral_keypair.public_key().to_bytes();
@@ -73,7 +73,7 @@ mod tests {
     #[test]
     fn test_kem() -> Result<()> {
         let mut rng = CsRng::new();
-        let key_pair = X25519Crypto::key_gen(&mut rng);
+        let key_pair = <X25519Crypto as Kem>::key_gen(&mut rng);
         let (K, E) = X25519Crypto::encaps(&mut rng, key_pair.public_key())
             .map_err(|err| anyhow::eyre!("{:?}", err))?;
         let res = X25519Crypto::decaps(key_pair.private_key(), &E)

--- a/src/hybrid_crypto/mod.rs
+++ b/src/hybrid_crypto/mod.rs
@@ -8,12 +8,12 @@ use crate::{
 
 mod block;
 mod dem;
-//mod header;
+mod header;
 mod kem;
 mod scanner;
 
 pub use block::Block;
-//pub use header::Metadata;
+pub use header::{Header, Metadata};
 use rand_core::{CryptoRng, RngCore};
 pub use scanner::BytesScanner;
 

--- a/src/hybrid_crypto/mod.rs
+++ b/src/hybrid_crypto/mod.rs
@@ -8,12 +8,12 @@ use crate::{
 
 mod block;
 mod dem;
-mod header;
+//mod header;
 mod kem;
 mod scanner;
 
 pub use block::Block;
-pub use header::Metadata;
+//pub use header::Metadata;
 use rand_core::{CryptoRng, RngCore};
 pub use scanner::BytesScanner;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 mod error;
 
 pub mod aes_hash_mmo;
@@ -18,7 +20,7 @@ pub mod sodium_bindings;
 
 pub use crate::error::Error;
 
-pub trait KeyTrait: Sized + Clone {
+pub trait KeyTrait: Sized + Clone + PartialEq + Debug {
     const LENGTH: usize;
     fn to_bytes(&self) -> Vec<u8>;
     fn try_from_bytes(bytes: Vec<u8>) -> Result<Self, Error>;

--- a/src/symmetric_crypto/aes_256_gcm_pure.rs
+++ b/src/symmetric_crypto/aes_256_gcm_pure.rs
@@ -1,11 +1,9 @@
-use std::{fmt::Display, vec::Vec};
-
+use crate::{symmetric_crypto::SymmetricCrypto, Error};
 use aes_gcm::{
     aead::{generic_array::GenericArray, Aead, NewAead, Payload},
     AeadInPlace, Aes256Gcm,
 }; // Or `Aes128Gcm`
-
-use crate::{symmetric_crypto::SymmetricCrypto, Error};
+use std::{fmt::Display, vec::Vec};
 
 // This implements AES 256 GCM, using a pure rust interface
 // It will use the AES native interface on the CPU if available

--- a/src/symmetric_crypto/aes_256_gcm_sodium.rs
+++ b/src/symmetric_crypto/aes_256_gcm_sodium.rs
@@ -353,9 +353,8 @@ impl SymmetricCrypto for Aes256GcmCrypto {
 #[cfg(test)]
 mod tests {
 
-    use crate::{entropy::CsRng, symmetric_crypto::nonce::NonceTrait};
-
     use super::*;
+    use crate::{entropy::CsRng, symmetric_crypto::nonce::NonceTrait};
 
     #[test]
     fn test_key() {

--- a/src/symmetric_crypto/mod.rs
+++ b/src/symmetric_crypto/mod.rs
@@ -8,9 +8,11 @@ pub mod aes_256_gcm_sodium;
 #[cfg(all(not(target_arch = "wasm32"), not(windows), feature = "libsodium"))]
 pub mod xchacha20;
 
-use crate::{Error, KeyTrait};
-use nonce::NonceTrait;
 use std::vec::Vec;
+
+use nonce::NonceTrait;
+
+use crate::{Error, KeyTrait};
 
 pub const MIN_DATA_LENGTH: usize = 1;
 

--- a/src/symmetric_crypto/xchacha20.rs
+++ b/src/symmetric_crypto/xchacha20.rs
@@ -121,7 +121,7 @@ mod tests {
     use super::{
         Key, Nonce, SymmetricCrypto, XChacha20Crypto, KEY_LENGTH, MAC_LENGTH, NONCE_LENGTH,
     };
-    use crate::{entropy::CsRng, symmetric_crypto::nonce::NonceTrait, KeyTrait};
+    use crate::{entropy::CsRng, symmetric_crypto::nonce::NonceTrait};
 
     #[test]
     fn test_key() {

--- a/src/symmetric_crypto/xchacha20.rs
+++ b/src/symmetric_crypto/xchacha20.rs
@@ -1,3 +1,5 @@
+use std::{sync::Once, vec::Vec};
+
 use crate::{
     sodium_bindings::{
         crypto_aead_xchacha20poly1305_ietf_ABYTES, crypto_aead_xchacha20poly1305_ietf_KEYBYTES,
@@ -7,8 +9,6 @@ use crate::{
     symmetric_crypto::{SymmetricCrypto, MIN_DATA_LENGTH},
     Error,
 };
-use std::sync::Once;
-use std::vec::Vec;
 
 static START: Once = Once::new();
 
@@ -118,11 +118,10 @@ impl SymmetricCrypto for XChacha20Crypto {
 
 #[cfg(test)]
 mod tests {
-    use crate::{entropy::CsRng, symmetric_crypto::nonce::NonceTrait};
-
     use super::{
         Key, Nonce, SymmetricCrypto, XChacha20Crypto, KEY_LENGTH, MAC_LENGTH, NONCE_LENGTH,
     };
+    use crate::{entropy::CsRng, symmetric_crypto::nonce::NonceTrait, KeyTrait};
 
     #[test]
     fn test_key() {


### PR DESCRIPTION
- `AsymmetricCrypto` trait implements hybrid crypto -> make it a real asymmetric trait
- Use KEM / DEM in `HEADER`
- Correct `DEM::ENCAPSULATION_OVERHEAD`