### PR TITLE
Add conversions from slices

### DIFF
--- a/src/asymmetric/ristretto/kem.rs
+++ b/src/asymmetric/ristretto/kem.rs
@@ -39,7 +39,7 @@ impl Kem for X25519Crypto {
             <Self::KeyPair as KeyPair>::PublicKey::LENGTH
                 + <Self::KeyPair as KeyPair>::PrivateKey::LENGTH,
         );
-        b.extend_from_slice(&shared_secret);
+        b.extend(shared_secret);
         b.extend_from_slice(&encapsulation);
         let secret_key = kdf::hkdf_256(&b, secret_key_length, HKDF_INFO)?;
         Ok((secret_key, encapsulation))

--- a/src/hybrid_crypto/block.rs
+++ b/src/hybrid_crypto/block.rs
@@ -192,7 +192,7 @@ where
         }
         //TODO: use transmute to make this faster ?
         Ok(Self {
-            nonce: <<S as SymmetricCrypto>::Nonce>::try_from_bytes(bytes.to_vec())?,
+            nonce: <<S as SymmetricCrypto>::Nonce>::try_from_bytes(bytes)?,
         })
     }
 

--- a/src/hybrid_crypto/header.rs
+++ b/src/hybrid_crypto/header.rs
@@ -135,7 +135,7 @@ where
 
         let metadata = if scanner.has_more() {
             // Nonce
-            let nonce = S::Nonce::try_from_bytes(scanner.next(S::Nonce::LENGTH)?.to_vec())?;
+            let nonce = S::Nonce::try_from_bytes(scanner.next(S::Nonce::LENGTH)?)?;
 
             // encrypted metadata
             let encrypted_metadata_size = scanner.read_u32()? as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,5 +21,5 @@ pub use crate::error::CryptoBaseError;
 pub trait KeyTrait: Sized + Clone {
     const LENGTH: usize;
     fn to_bytes(&self) -> Vec<u8>;
-    fn try_from_bytes(bytes: Vec<u8>) -> Result<Self, CryptoBaseError>;
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self, CryptoBaseError>;
 }

--- a/src/symmetric_crypto/key.rs
+++ b/src/symmetric_crypto/key.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(try_from = "Vec<u8>", into = "Vec<u8>")]
+#[serde(try_from = "&[u8]", into = "Vec<u8>")]
 pub struct Key<const KEY_LENGTH: usize>(pub [u8; KEY_LENGTH]);
 
 impl<const KEY_LENGTH: usize> Key<KEY_LENGTH> {
@@ -31,7 +31,7 @@ impl<const KEY_LENGTH: usize> KeyTrait for Key<KEY_LENGTH> {
         self.as_bytes().to_vec()
     }
 
-    fn try_from_bytes(bytes: Vec<u8>) -> Result<Self, CryptoBaseError> {
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self, CryptoBaseError> {
         Self::try_from(bytes)
     }
 }

--- a/src/symmetric_crypto/nonce.rs
+++ b/src/symmetric_crypto/nonce.rs
@@ -11,7 +11,7 @@ use std::{
 pub trait NonceTrait: Sized + Clone {
     const LENGTH: usize;
     fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self;
-    fn try_from_bytes(bytes: Vec<u8>) -> Result<Self, CryptoBaseError>;
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self, CryptoBaseError>;
     #[must_use]
     fn increment(&self, increment: usize) -> Self;
     #[must_use]
@@ -31,7 +31,7 @@ impl<const NONCE_LENGTH: usize> NonceTrait for Nonce<NONCE_LENGTH> {
         Self(bytes)
     }
 
-    fn try_from_bytes(bytes: Vec<u8>) -> Result<Self, CryptoBaseError> {
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self, CryptoBaseError> {
         let len = bytes.len();
         let b: [u8; NONCE_LENGTH] = bytes.try_into().map_err(|_| CryptoBaseError::SizeError {
             given: len,
@@ -65,7 +65,7 @@ impl<const NONCE_LENGTH: usize> TryFrom<Vec<u8>> for Nonce<NONCE_LENGTH> {
     type Error = CryptoBaseError;
 
     fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
-        Self::try_from_bytes(bytes)
+        Self::try_from_bytes(&bytes)
     }
 }
 
@@ -73,7 +73,7 @@ impl<'a, const NONCE_LENGTH: usize> TryFrom<&'a [u8]> for Nonce<NONCE_LENGTH> {
     type Error = CryptoBaseError;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self, Self::Error> {
-        Self::try_from_bytes(bytes.to_vec())
+        Self::try_from_bytes(bytes)
     }
 }
 


### PR DESCRIPTION
from issue #18 

> - Cannot borrow a slice of u8 from the key, take a Vec<u8> then borrow a slice from this vec.

Keys share common trait `KeyTrait`, which is implemented by several type of keys. One of these implementations (ristretto `X25519PublicKey`) cannot expose to the user a borrowed slice, as the value is based on temporary variable (returned value is a compressed view of the key), so we need owned value here.

We could think of a solution using `Cow<'a, [u8]>`, but it introduces new lifetimes almost everywhere and it is not worth it.

fixes #18 